### PR TITLE
Fix langlist routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*~
+/phpBB3/cache/*
+!/phpBB3/cache/.htaccess
+!/phpBB3/cache/index.htm
+/phpBB3/config*.php
+/phpBB3/files/*
+/phpBB3/images/avatars/gallery/*
+/phpBB3/images/avatars/upload/*
+/phpBB3/images/ranks/*

--- a/phpBB3/ext/unilang/languages/config/routing.yml
+++ b/phpBB3/ext/unilang/languages/config/routing.yml
@@ -1,7 +1,7 @@
-unilang_languages_controller:
+unilang_languages_info:
     pattern: /lang_info
     defaults: { _controller:unilang.languages.controller:info }
 
-unilang_languages_controller:
+unilang_languages_wikidirect:
     pattern: /wikidirect
     defaults: { _controller:unilang.languages.controller:wikidirect }

--- a/phpBB3/ext/unilang/languages/event/main_listener.php
+++ b/phpBB3/ext/unilang/languages/event/main_listener.php
@@ -64,7 +64,7 @@ class main_listener implements EventSubscriberInterface
     public function add_page_header_link($event) {
         //add the page link for the language list info page
         $this->template->assign_vars(array(
-            'U_LANG_INFO_PAGE'   => $this->helper->route('unilang_languages_controller'),
+            'U_LANG_INFO_PAGE'   => $this->helper->route('unilang_languages_info'),
         ));
     }
 


### PR DESCRIPTION
Each route needs to have an unique name, fixed that, and changed the route leading to language list.

Btw. the [lang] BBCode's link should now lead to `forum.unilang.org/app.php/wikidirect?lang={LANG}` instead of the www.unilang.org link. This can only be changed in ACP though.

Oh, also: a simple .gitignore.
