### PR TITLE
Add 3 virtual keyboard schemes and enhance it

### DIFF
--- a/phpBB3/ext/unilang/virtualkeyboard/config/routing.yml
+++ b/phpBB3/ext/unilang/virtualkeyboard/config/routing.yml
@@ -1,0 +1,4 @@
+unilang_virtualkeyboard_ajax_charsets:
+  pattern: /virtualkeyboard/charsets
+  defaults:
+    _controller: unilang.virtualkeyboard.controller:ajax_charsets

--- a/phpBB3/ext/unilang/virtualkeyboard/config/services.yml
+++ b/phpBB3/ext/unilang/virtualkeyboard/config/services.yml
@@ -1,0 +1,15 @@
+services:
+    unilang.virtualkeyboard.controller:
+        class: unilang\virtualkeyboard\controller\main
+        arguments:
+            - @config
+            - @controller.helper
+            - @template
+            - @request
+    unilang.virtualkeyboard.listener:
+        class: unilang\virtualkeyboard\event\main_listener
+        arguments:
+            - @controller.helper
+            - @template
+        tags:
+            - { name: event.listener }

--- a/phpBB3/ext/unilang/virtualkeyboard/controller/main.php
+++ b/phpBB3/ext/unilang/virtualkeyboard/controller/main.php
@@ -1,0 +1,48 @@
+<?php
+/*
+*
+* @package unilang
+* @author Patryk Kalinowski
+* @copyright (c) 2015 UniLang Language Community
+* @license http://opensource.org/licenses/gpl-license.php GNU Public License
+*
+*/
+
+namespace unilang\virtualkeyboard\controller;
+
+if (!defined('IN_PHPBB')) {
+    exit;
+}
+
+
+class main {
+    /* @var \phpbb\config\config */
+    protected $config;
+
+    /* @var \phpbb\controller\helper */
+    protected $helper;
+
+    /* @var \phpbb\template\template */
+    protected $template;
+
+    /**
+    * Constructor
+    *
+    * @param \phpbb\config\config $config
+    * @param \phpbb\controller\helper $helper
+    * @param \phpbb\template\template $template
+    */
+    public function __construct(\phpbb\config\config $config, \phpbb\controller\helper $helper, \phpbb\template\template $template, $request)
+    {
+        $this->config = $config;
+        $this->helper = $helper;
+        $this->template = $template;
+        $this->request = $request;
+    }
+
+    public function ajax_charsets()
+    {
+        return $this->helper->render('unilang_virtualkeyboard_charsets.html');
+    }
+
+}

--- a/phpBB3/ext/unilang/virtualkeyboard/event/main_listener.php
+++ b/phpBB3/ext/unilang/virtualkeyboard/event/main_listener.php
@@ -1,0 +1,66 @@
+<?php
+/*
+*
+* @package unilang
+* @name Virtual Keyboard Extension
+* @copyright (c) 2007-2015 UniLang
+* @author Patryk Kalinowski
+* @license http://opensource.org/licenses/gpl-license.php GNU Public License 
+*
+*/
+
+namespace unilang\virtualkeyboard\event;
+
+/**
+* @ignore
+*/
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+/**
+* Event listener
+*/
+class main_listener implements EventSubscriberInterface
+{
+  static public function getSubscribedEvents() {
+    return array(
+      'core.user_setup' => 'load_language_on_setup', 
+      'core.posting_modify_template_vars'  => 'posting_modify_template_vars',
+    );
+  }
+
+  /* @var \phpbb\controller\helper */
+  protected $helper;
+
+  /* @var \phpbb\template\template */
+  protected $template;
+
+  /**
+  * Constructor
+  *
+  * @param \phpbb\controller\helper $helper Controller helper object
+  * @param \phpbb\template $template Template object
+  */
+  public function __construct(\phpbb\controller\helper $helper, \phpbb\template\template $template) {
+    $this->helper = $helper;
+    $this->template = $template;
+  }
+
+
+  public function load_language_on_setup($event) {
+    $event['lang_set_ext'] = array_merge($event['lang_set_ext'], array(
+      array(
+        'ext_name' => 'unilang/virtualkeyboard',
+        'lang_set' => 'common'
+      )
+    ));
+  }
+
+  public function posting_modify_template_vars($event) {
+    $this->template->assign_vars(array(
+        'U_AJAX_VK_CHARSETS'   => $this->helper->route('unilang_virtualkeyboard_ajax_charsets')
+    ));
+  }
+
+
+
+
+}

--- a/phpBB3/ext/unilang/virtualkeyboard/language/en/common.php
+++ b/phpBB3/ext/unilang/virtualkeyboard/language/en/common.php
@@ -1,0 +1,32 @@
+<?php
+/*
+*
+* @package unilang
+* @name Translations
+* @copyright (c) 2007-2015 UniLang
+* @author Patryk Kalinowski
+* @license http://opensource.org/licenses/gpl-license.php GNU Public License 
+*
+*/
+
+if (!defined('IN_PHPBB')) {
+    exit;
+}
+
+if (empty($lang) || !is_array($lang)) {
+    $lang = array();
+}
+
+
+$lang = array_merge($lang, array(
+    'VKBD_SHOW' => "Show virtual keyboard",
+    'VKBD_HIDE' => "Hide virtual keyboard",
+    'VKBD_EXTENDED' => "Extended",
+    'VKBD_PLEASE_WAIT' => "Please wait...",
+    'VKBD_IPA' => "IPA",
+    'VKBD_LATN' => "Latin/Roman",
+    'VKBD_CYRL' => "Cyrillic",
+    'VKBD_GREK' => "Greek"
+));
+
+?>

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/event/posting_editor_message_after.html
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/event/posting_editor_message_after.html
@@ -1,238 +1,63 @@
+<!-- IF not $INCLUDED_JQUERY_COOKIE -->
+  <!-- INCLUDEJS @unilang_virtualkeyboard/js/jquery.cookie.1.4.1.js -->
+  <!-- DEFINE $INCLUDED_JQUERY_COOKIE = true -->
+<!-- ENDIF -->
 <!-- IF not $INCLUDED_UNILANG_VIRTUALKEYBOARD -->
   <!-- INCLUDEJS @unilang_virtualkeyboard/js/virtualkeyboard.js -->
   <!-- DEFINE $INCLUDED_UNILANG_VIRTUALKEYBOARD = true -->
 <!-- ENDIF -->
 
 <style>
-  #ulkvbd .ulvkbd-buttonlist > label {
+  #ulvkbd .ulvkbd-buttonlist label {
     -webkit-border-radius: 4px; border-radius: 4px;
     color: #39392e; background-color: #c1c2b7;
     font-size: 0.9em;
     padding: 6px 5px;
-    float: left;
-    margin: 2px 7px;
+    margin: 2px 0;
   }
-  #ulkvbd .ulvkbd-buttonlist > label:first-child {
-    margin-left: 0px;
+  #ulvkbd .ulvkbd-buttonlist div {
+    display: inline;
   }
-  #ulkvbd .ulvkbd-buttonlist > button {
+
+  #ulvkbd .ulvkbd-buttonlist div > span {
+    display: inline-block;
+  }
+  #ulvkbd .ulvkbd-buttonlist button {
+    min-width: 20px;
     margin: 2px 0; padding: 5px;
     border: 0;
-    float: left;
   }
-  #ulkvbd .ulvkbd-buttonlist > button:hover {
+  #ulvkbd .ulvkbd-buttonlist button:hover {
     cursor: pointer; cursor: hand;
     background-color: #EBEBEB;
   }
 </style>
 
-<div id="ulkvbd">
+<div id="ulvkbd">
 
-  <div id="ulkvbd-toggle" style="display: inline">
-    <a href="#" style="display: none">Hide virtual keyboard</a>
-    <a href="#">Show virtual keyboard</a>
+  <div id="ulvkbd-toggle">
+    <a href="#" style="display: none">{L_VKBD_HIDE}</a>
+    <a href="#">{L_VKBD_SHOW}</a>
 
-    <span id="ulkvbd-layout-select" style="display: none">
+    <span id="ulvkbd-layout-select" style="display: none">
       <select style="display: inline">
-        <option value="IPA">IPA</option>
-<!--         <option value="Latn">Latin/Roman</option>
-        <option value="Cyrl">Cyrillic</option>
-        <option value="Grek">Greek</option> -->
+        <option value="IPA">{L_VKBD_IPA}</option>
+        <option value="Latn" data-showext="1">{L_VKBD_LATN}</option>
+        <option value="Cyrl" data-showext="1">{L_VKBD_CYRL}</option>
+        <option value="Grek" data-showext="1">{L_VKBD_GREK}</option>
       </select>
+
+      <span id="ulvkbd-layout-extended-toggle" style="display: none">
+        <label>
+          <input type="checkbox" id="ulvkbd-layout-extended">
+          {L_VKBD_EXTENDED}
+        </label>
+      </span>
     </span>
   </div>
 
-  <div id="ulkvbd-box" data-loaded="1" style="display: none">
-
-    <div data-layout="IPA" class="ulvkbd-buttonlist ulkvbd-layout-IPA" style="display: none">
-      <label>Vowels</label>
-
-      <button title="close central unrounded vowel">ɨ</button>
-      <button title="close central rounded vowel">ʉ</button>
-      <button title="close back unrounded vowel">ɯ</button>
-      <button title="near-close near-front unrounded vowel">ɪ</button>
-      <button title="near-close near-front rounded vowel">ʏ</button>
-      <button title="near-close near-back rounded vowel">ʊ</button>
-      <button title="close-mid front rounded vowel">ø</button>
-      <button title="close-mid central unrounded vowel">ɘ</button>
-      <button title="close-mid central rounded vowel">ɵ</button>
-      <button title="close-mid back unrounded vowel">ɤ</button>
-      <button title="mid-central vowel">ə</button>
-      <button title="open-mid front unrounded vowel">ɛ</button>
-      <button title="open-mid front rounded vowel">œ</button>
-      <button title="open-mid central unrounded vowel">ɜ</button>
-      <button title="open-mid central rounded vowel">ɞ</button>
-      <button title="open-mid back unrounded vowel">ʌ</button>
-      <button title="open-mid back rounded vowel">ɔ</button>
-      <button title="near-open front unrounded vowel">æ</button>
-      <button title="near-open central vowel">ɐ</button>
-      <button title="open front rounded vowel">ɶ</button>
-      <button title="open back unrounded vowel">ɑ</button>
-      <button title="open back rounded vowel">ɒ</button>
-
-      <label>Pulmonic consonants</label>
-
-      <button title="voiceless retroflex plosive">ʈ</button>
-      <button title="voiced retroflex plosive">ɖ</button>
-      <button title="voiced palatal plosive">ɟ</button>
-      <button title="voiced uvular plosive">ɢ</button>
-      <button title="glottal stop">ʔ</button>
-      <button title="labiodental nasal">ɱ</button>
-      <button title="retroflex nasal">ɳ</button>
-      <button title="palatal nasal">ɲ</button>
-      <button title="velar nasal">ŋ</button>
-      <button title="uvular nasal">ɴ</button>
-      <button title="bilabial trill">ʙ</button>
-      <button title="uvular trill">ʀ</button>
-      <button title="labiodental flap">ⱱ</button>
-      <button title="alveolar tap">ɾ</button>
-      <button title="retroflex flap">ɽ</button>
-      <button title="voiceless vilabial fricative">ɸ</button>
-      <button title="voiced vilabial fricative">β</button>
-      <button title="voiceless dental fricative">θ</button>
-      <button title="voiced dental fricative">ð</button>
-      <button title="voiceless postalveolar fricative">ʃ</button>
-      <button title="voiced postalveolar fricative">ʒ</button>
-      <button title="voiceless retroflex fricative">ʂ</button>
-      <button title="voiced retroflex fricative">ʐ</button>
-      <button title="voiceless palatal fricative">ç</button>
-      <button title="voiced palatal fricative">ʝ</button>
-      <button title="voiced velar fricative">ɣ</button>
-      <button title="voiceless uvular fricative">χ</button>
-      <button title="voiced uvular fricative">ʁ</button>
-      <button title="voiceless pharyngeal fricative">ħ</button>
-      <button title="voiced pharyngeal fricative">ʕ</button>
-      <button title="voiced glottal fricative">ɦ</button>
-      <button title="voiceless alveolar lateral fricative">ɬ</button>
-      <button title="voiced alveolar lateral fricative">ɮ</button>
-      <button title="labiodental approximant">ʋ</button>
-      <button title="alveolar approximant">ɹ</button>
-      <button title="retroflex approximant">ɻ</button>
-      <button title="velar approximant">ɰ</button>
-      <button title="retroflex lateral approximant">ɭ</button>
-      <button title="palatal lateral approximant">ʎ</button>
-      <button title="velar lateral approximant">ʟ</button>
-      <button title="voiceless labio-velar approximant">ʍ</button>
-      <button title="voiced labial-palatal approximant">ɥ</button>
-      <button title="voiceless epiglottal fricative">ʜ</button>
-      <button title="voiced epiglottal fricative">ʢ</button>
-      <button title="epiglottal plosive">ʡ</button>
-      <button title="voiceless alveo-palatal fricative">ɕ</button>
-      <button title="voiceless alveo-palatal fricative">ʑ</button>
-      <button title="alveolar lateral flap">ɺ</button>
-      <button title="simultaneous [ʃ] and [x]">ɧ</button>
-      <button title="velarized alveolar lateral approximant">ɫ</button>
-
-      <button title="voiceless alveolar affricate">t͡s</button>
-      <button title="voiced alveolar affricate">d͡z</button>
-      <button title="voiceless postalveolar affricate">t͡ʃ</button>
-      <button title="voiced postalveolar affricate">d͡ʒ</button>
-      <button title="voiceless alveo-palatal affricate">t͡ɕ</button>
-      <button title="voiced alveo-palatal affricate">d͡ʑ</button>
-
-      <label>Non-pulmonic consonants</label>
-
-      <button title="bilabial click">ʘ</button>
-      <button title="dental click">ǀ</button>
-      <button title="(post)alveolar click">ǃ</button>
-      <button title="palatoalveolar click">ǂ</button>
-      <button title="alveolar lateral click">ǁ</button>
-      <button title="voiced bilabial implosive">ɓ</button>
-      <button title="voiced dental/alveolar implosive">ɗ</button>
-      <button title="voiced palatal implosive">ʄ</button>
-      <button title="voiced velar implosive">ɠ</button>
-      <button title="voiced uvular implosive">ʛ</button>
-      <button title="ejective">ʼ</button>
-
-      <label>Suprasegmentals</label>
-
-      <button title="primary stress">ˈ</button>
-      <button title="secondary stress">ˌ</button>
-      <button title="long">ː</button>
-      <button title="half-long">ˑ</button>
-      <button data-char="̆" title="extra-short">&nbsp; ̆</button>
-      <button title="linking">‿</button>
-
-      <label>Tones and word accents</label>
-
-      <button title="extra-high">˥</button>
-      <button title="high">˦</button>
-      <button title="mid">˧</button>
-      <button title="low">˨</button>
-      <button title="extra-low">˩</button>
-      <button title="rising">˩˥</button>
-      <button title="falling">˥˩</button>
-      <button title="high rising">˦˥</button>
-      <button title="low rising">˩˨</button>
-      <button title="rising-falling">˧˦˧</button>
-
-<!--       <button data-char="̋" title="extra-high">&nbsp; ̋</button>
-      <button data-char="́" title="high">&nbsp; ́</button>
-      <button data-char="̄" title="mid">&nbsp; ̄</button>
-      <button data-char="̀" title="low">&nbsp; ̀</button>
-      <button data-char="̏" title="extra-low">&nbsp; ̏</button>
-      <button data-char="̌" title="rising">&nbsp; ̌</button>
-      <button data-char="̂" title="falling">&nbsp; ̂</button>
-      <button data-char="᷄" title="high rising">&nbsp; ᷄</button>
-      <button data-char="᷅" title="low rising">&nbsp; ᷅</button>
-      <button data-char="᷈" title="rising-falling">&nbsp; ᷈</button> -->
-
-      <button title="downstep">↓</button>
-      <button title="upstep">↑</button>
-      <button title="global rise">↗</button>
-      <button title="global fall">↘</button>
-
-      <label>Diacritics</label>
-
-      <button data-char="̥" title="voiceless">&nbsp; ̥</button>
-      <button data-char="̊" title="voiceless">&nbsp; ̊</button>
-      <button data-char="̬" title="voiced">&nbsp; ̬</button>
-      <button data-char="̃" title="nasalized">&nbsp; ̃</button>
-      <button data-char="̩" title="syllabic">&nbsp; ̩</button>
-      <button data-char="̯" title="non-syllabic">&nbsp; ̯</button>
-      <button data-char="̝" title="raised">&nbsp; ̝</button>
-      <button data-char="̞" title="lowered">&nbsp; ̞</button>
-      <button data-char="̟" title="advanced">&nbsp; ̟</button>
-      <button data-char="̠" title="retracted">&nbsp; ̠</button>
-      <button data-char="̪" title="dental">&nbsp; ̪</button>
-      <button data-char="̺" title="apical">&nbsp; ̺</button>
-      <button data-char="̹" title="more rounded">&nbsp; ̹</button>
-      <button data-char="̜" title="less rounded">&nbsp; ̜</button>
-      <button data-char="̽" title="mid-centralized">&nbsp; ̽</button>
-      <button data-char="̤" title="breathy voiced">&nbsp; ̤</button>
-      <button data-char="̰" title="creaky voiced">&nbsp; ̰</button>
-      <button data-char="̼" title="linguolabial">&nbsp; ̼</button>
-      <button data-char="̴" title="velarized or pharyngealized">&nbsp; ̴</button>
-      <button data-char="̘" title="advanced tongue root">&nbsp; ̘</button>
-      <button data-char="̙" title="retracted tongue root">&nbsp; ̙</button>
-      <button data-char="̻" title="laminal">&nbsp; ̻</button>
-      <button data-char="̚" title="not audibly released">&nbsp; ̚</button>
-
-      <button title="syllabic or schwa">ᵊ</button>
-      <button title="aspirated">ʰ</button>
-      <button title="labialized">ʷ</button>
-      <button title="palatalized">ʲ</button>
-      <button title="velarized">ˠ</button>
-      <button title="pharyngealized">ˤ</button>
-      <button title="nasal release">ⁿ</button>
-      <button title="lateral release">ˡ</button>
-      <button title="breathy-voice aspirated">ʱ</button>
-      <button title="rhotacized">˞</button>
-
-    </div>
-
-<!--     <div data-layout="Latn" class="ulvkbd-buttonlist ulkvbd-layout-Latn" style="display: none">
-      
-    </div>
-
-    <div data-layout="Cyrl" class="ulvkbd-buttonlist ulkvbd-layout-Cyrl" style="display: none">
-
-    </div>
-
-    <div data-layout="Grek" class="ulvkbd-buttonlist ulkvbd-layout-Grek" style="display: none">
-
-    </div> -->
-
+  <div id="ulvkbd-box" data-loaded="0" data-uri="{U_AJAX_VK_CHARSETS}" style="display: none">
+    <em>{L_VKBD_PLEASE_WAIT}</em>
   </div>
 
   <div style="clear:both"></div>

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/jquery.cookie.1.4.1.js
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/jquery.cookie.1.4.1.js
@@ -1,0 +1,117 @@
+/*!
+ * jQuery Cookie Plugin v1.4.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // CommonJS
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+
+  var pluses = /\+/g;
+
+  function encode(s) {
+    return config.raw ? s : encodeURIComponent(s);
+  }
+
+  function decode(s) {
+    return config.raw ? s : decodeURIComponent(s);
+  }
+
+  function stringifyCookieValue(value) {
+    return encode(config.json ? JSON.stringify(value) : String(value));
+  }
+
+  function parseCookieValue(s) {
+    if (s.indexOf('"') === 0) {
+      // This is a quoted cookie as according to RFC2068, unescape...
+      s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+    }
+
+    try {
+      // Replace server-side written pluses with spaces.
+      // If we can't decode the cookie, ignore it, it's unusable.
+      // If we can't parse the cookie, ignore it, it's unusable.
+      s = decodeURIComponent(s.replace(pluses, ' '));
+      return config.json ? JSON.parse(s) : s;
+    } catch(e) {}
+  }
+
+  function read(s, converter) {
+    var value = config.raw ? s : parseCookieValue(s);
+    return $.isFunction(converter) ? converter(value) : value;
+  }
+
+  var config = $.cookie = function (key, value, options) {
+
+    // Write
+
+    if (value !== undefined && !$.isFunction(value)) {
+      options = $.extend({}, config.defaults, options);
+
+      if (typeof options.expires === 'number') {
+        var days = options.expires, t = options.expires = new Date();
+        t.setTime(+t + days * 864e+5);
+      }
+
+      return (document.cookie = [
+        encode(key), '=', stringifyCookieValue(value),
+        options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+        options.path    ? '; path=' + options.path : '',
+        options.domain  ? '; domain=' + options.domain : '',
+        options.secure  ? '; secure' : ''
+      ].join(''));
+    }
+
+    // Read
+
+    var result = key ? undefined : {};
+
+    // To prevent the for loop in the first place assign an empty array
+    // in case there are no cookies at all. Also prevents odd result when
+    // calling $.cookie().
+    var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+    for (var i = 0, l = cookies.length; i < l; i++) {
+      var parts = cookies[i].split('=');
+      var name = decode(parts.shift());
+      var cookie = parts.join('=');
+
+      if (key && key === name) {
+        // If second argument (value) is a function it's a converter...
+        result = read(cookie, value);
+        break;
+      }
+
+      // Prevent storing a cookie that we couldn't decode.
+      if (!key && (cookie = read(cookie)) !== undefined) {
+        result[name] = cookie;
+      }
+    }
+
+    return result;
+  };
+
+  config.defaults = {};
+
+  $.removeCookie = function (key, options) {
+    if ($.cookie(key) === undefined) {
+      return false;
+    }
+
+    // Must not alter options, thus extending a fresh object...
+    $.cookie(key, '', $.extend({}, options, { expires: -1 }));
+    return !$.cookie(key);
+  };
+
+}));

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/virtualkeyboard.js
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/virtualkeyboard.js
@@ -74,7 +74,7 @@
       if ($.cookie('unilang_vkbd_scheme') != undefined)
         $("#ulvkbd-layout-select > select").val($.cookie('unilang_vkbd_scheme'));
       if ($.cookie('unilang_vkbd_ext') != undefined)
-        $("#ulvkbd-layout-extended").prop('checked', $.cookie('unilang_vkbd_ext'));
+        $("#ulvkbd-layout-extended").prop('checked', $.cookie('unilang_vkbd_ext') === 'true');
       if ($.cookie('unilang_vkbd_show') === 'true')
         showCharbox();
     });

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/virtualkeyboard.js
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/js/virtualkeyboard.js
@@ -1,5 +1,11 @@
-
-// virtual keyboard
+/*!
+ * Unilang Virtual Keyboard extension
+ * Part of Unilang Forum
+ * https://github.com/proycon/unilangforum
+ *
+ * Copyright 2015 Patryk Kalinowski
+ * Released under the GPL-3.0 license
+ */
 
 (function($) {
 
@@ -30,28 +36,62 @@
 
   var updateLayout = function() {
     $(".ulvkbd-buttonlist").hide();
-    var layout = $("#ulkvbd-layout-select > select").val();
-    $(".ulkvbd-layout-" + layout).show();
+    var layout = $("#ulvkbd-layout-select > select").val();
+    $(".ulvkbd-layout-" + layout).show();
+    var selOption = $("#ulvkbd-layout-select option[value=" + layout + "]");
+    $("#ulvkbd-layout-extended-toggle").toggle(!!selOption.data('showext'));
+  }
+
+  var updateExtended = function() {
+    $(".ulvkbd-buttonlist [data-ext]").css("display", $("#ulvkbd-layout-extended").is(':checked') ? 'inline' : 'none');
+  }
+
+  var showCharbox = function() {
+    $('#ulvkbd-toggle > a, #ulvkbd-box, #ulvkbd-layout-select').toggle();
+
+    var box = $('#ulvkbd-box');
+    $.cookie('unilang_vkbd_show', (box.css('display') !== 'none'));
+    if( !box.data('loaded') ) {
+      box.load(box.data('uri'), {}, function() {
+        updateLayout();
+        updateExtended();
+        box.data('loaded', true);
+
+        $('.ulvkbd-buttonlist button').click(function( event ) {
+          var messageBox = $('#message'); 
+          var _c = ($(this).data('char') ? $(this).data('char') : $(this).text());
+          event.preventDefault();
+          insertAtCaret(messageBox, _c);
+          messageBox.focus();
+        });
+      });
+    }
   }
 
   $(function() {
 
-    $(document).ready(updateLayout);
-    $("#ulkvbd-layout-select > select").change(updateLayout);
-
-    $('#ulkvbd-toggle > a').click(function( event ) {
-      event.preventDefault();
-      $('#ulkvbd-toggle > a, #ulkvbd-box, #ulkvbd-layout-select').toggle();
-      // $('#ulkvbd-box').toggle();
-      // $("#ulkvbd-layout-select").toggle();
+    $(document).ready(function() {
+      if ($.cookie('unilang_vkbd_scheme') != undefined)
+        $("#ulvkbd-layout-select > select").val($.cookie('unilang_vkbd_scheme'));
+      if ($.cookie('unilang_vkbd_ext') != undefined)
+        $("#ulvkbd-layout-extended").prop('checked', $.cookie('unilang_vkbd_ext'));
+      if ($.cookie('unilang_vkbd_show') === 'true')
+        showCharbox();
     });
 
-    $('.ulvkbd-buttonlist > button').click(function( event ) {
-      var messageBox = $('#message'); 
-      var _c = ($(this).data('char') ? $(this).data('char') : $(this).text());
+    $("#ulvkbd-layout-select > select").change(function() {
+      $.cookie('unilang_vkbd_scheme', $(this).val());
+      updateLayout();
+    });
+
+    $('#ulvkbd-toggle > a').click(function( event ) {
       event.preventDefault();
-      insertAtCaret(messageBox, _c);
-      messageBox.focus();
+      showCharbox();
+    });
+
+    $('#ulvkbd-layout-extended').change(function() {
+      $.cookie('unilang_vkbd_ext', $(this).is(':checked'));
+      updateExtended();
     });
 
   });

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/unilang_virtualkeyboard_charsets.html
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/unilang_virtualkeyboard_charsets.html
@@ -213,14 +213,14 @@
      --><span><button>Ê</button><button>ê</button></span><!--
      --><span><button>Î</button><button>î</button></span><!--
      --><span><button>Ô</button><button>ô</button></span><!--
-     --><span data-ext><button>Û</button><button>û</button></span><!--
-     --><span><button>Ŷ</button><button>ŷ</button></span><!--
-     --><span><button>Ĉ</button><button>ĉ</button></span><!--
-     --><span><button>Ĝ</button><button>ĝ</button></span><!--
-     --><span><button>Ĥ</button><button>ĥ</button></span><!--
-     --><span><button>Ĵ</button><button>ĵ</button></span><!--
-     --><span><button>Ŝ</button><button>ŝ</button></span><!--
-     --><span data-ext><button>Ŵ</button><button>ŵ</button></span>
+     --><span><button>Û</button><button>û</button></span><!--
+     --><span data-ext><button>Ŷ</button><button>ŷ</button></span><!-- Welsh
+     --><span data-ext><button>Ĉ</button><button>ĉ</button></span><!-- Esperanto
+     --><span data-ext><button>Ĝ</button><button>ĝ</button></span><!-- Esperanto
+     --><span data-ext><button>Ĥ</button><button>ĥ</button></span><!-- Esperanto
+     --><span data-ext><button>Ĵ</button><button>ĵ</button></span><!-- Esperanto
+     --><span data-ext><button>Ŝ</button><button>ŝ</button></span><!-- Esperanto
+     --><span data-ext><button>Ŵ</button><button>ŵ</button></span><!-- Welsh -->
       </div>
 
       <label>Umlauts and diaereses</label>
@@ -231,7 +231,7 @@
      --><span><button>Ï</button><button>ï</button></span><!--
      --><span><button>Ö</button><button>ö</button></span><!--
      --><span><button>Ü</button><button>ü</button></span><!--
-     --><span><button>Ÿ</button><button>ÿ</button></span>
+     --><span data-ext><button>Ÿ</button><button>ÿ</button></span><!-- French (rare) -->
       </div>
 
       <div>
@@ -270,10 +270,10 @@
         <label>Cedilla</label>
 
         <span><button>Ç</button><button>ç</button></span><!--
-     --><span><button>Ģ</button><button>ģ</button></span><!--
-     --><span><button>Ķ</button><button>ķ</button></span><!--
-     --><span><button>Ļ</button><button>ļ</button></span><!--
-     --><span><button>Ņ</button><button>ņ</button></span><!--
+     --><span data-ext><button>Ģ</button><button>ģ</button></span><!-- Latvian
+     --><span data-ext><button>Ķ</button><button>ķ</button></span><!-- Latvian
+     --><span data-ext><button>Ļ</button><button>ļ</button></span><!-- Latvian
+     --><span data-ext><button>Ņ</button><button>ņ</button></span><!-- Latvian
      --><span><button>Ş</button><button>ş</button></span>
       </div>
 
@@ -287,7 +287,7 @@
      --><span><button>Ō</button><button>ō</button></span><!--
      --><span><button>Ū</button><button>ū</button></span><!--
      --><span data-ext><button>Ȳ</button><button>ȳ</button></span><!--
-     --><span><button>Ǣ</button><button>ǣ</button></span>
+     --><span data-ext><button>Ǣ</button><button>ǣ</button></span>
       </div>
 
 
@@ -318,7 +318,7 @@
      --><span data-ext><button>Ĕ</button><button>ĕ</button></span><!--
      --><span data-ext><button>Ĭ</button><button>ĭ</button></span><!--
      --><span data-ext><button>Ŏ</button><button>ŏ</button></span><!--
-     --><span><button>Ŭ</button><button>ŭ</button></span><!--
+     --><span data-ext><button>Ŭ</button><button>ŭ</button></span><!-- Esperanto
      --><span><button>Ğ</button><button>ğ</button></span>
       </div>
 
@@ -435,7 +435,6 @@
      --><span><button>К</button><button>к</button></span><!--
      --><span><button>Л</button><button>л</button></span><!--
      --><span><button>Љ</button><button>љ</button></span><!--
-     --><span><button>Љ</button><button>љ</button></span><!--
      --><span><button>М</button><button>м</button></span><!--
      --><span><button>Н</button><button>н</button></span><!--
      --><span><button>Њ</button><button>њ</button></span><!--
@@ -446,7 +445,7 @@
      --><span data-ext><button>С́</button><button>с́</button></span><!--
      --><span><button>Т</button><button>т</button></span><!--
      --><span><button>Ћ</button><button>ћ</button></span><!--
-     --><span><button>Ќ</button><button>ќ</button></span><!--
+     --><span data-ext><button>Ќ</button><button>ќ</button></span><!--
      --><span><button>У</button><button>у</button></span><!--
      --><span data-ext><button>Ў</button><button>ў</button></span><!--
      --><span><button>Ф</button><button>ф</button></span><!--
@@ -455,7 +454,6 @@
      --><span><button>Ч</button><button>ч</button></span><!--
      --><span><button>Џ</button><button>џ</button></span><!--
      --><span><button>Ш</button><button>ш</button></span><!--
-     --><span><button>Щ</button><button>щ</button></span><!--
      --><span><button>Щ</button><button>щ</button></span><!--
      --><span><button>Ъ</button><button>ъ</button></span><!--
      --><span><button>Ы</button><button>ы</button></span><!--
@@ -484,17 +482,21 @@
         <label>Non-slavic</label>
 
         <span><button>Ӏ</button><button>ӏ</button></span><!--
+     --><span><button>Ӣ</button><button>ӣ</button></span><!-- Tajik
+     --><span><button>Ӯ</button><button>ӯ</button></span><!-- Tajik
      --><span><button>Ә</button><button>ә</button></span><!--
      --><span><button>Ғ</button><button>ғ</button></span><!--
      --><span><button>Ҙ</button><button>ҙ</button></span><!--
-     --><span><button>Ҫ</button><button>ҫ</button></span><!--
      --><span><button>Ҡ</button><button>ҡ</button></span><!--
      --><span><button>Қ</button><button>қ</button></span><!--
      --><span><button>Ң</button><button>ң</button></span><!--
+     --><span><button>Һ</button><button>һ</button></span><!--
      --><span><button>Ө</button><button>ө</button></span><!--
+     --><span><button>Ҫ</button><button>ҫ</button></span><!--
      --><span><button>Ү</button><button>ү</button></span><!--
      --><span><button>Ұ</button><button>ұ</button></span><!--
-     --><span><button>Һ</button><button>һ</button></span>
+     --><span><button>Ҳ</button><button>ҳ</button></span><!--
+     --><span><button>Ҷ</button><button>ҷ</button></span><!-- Tajik -->
       </div>
 
       <div data-ext>
@@ -515,7 +517,9 @@
      --><span><button>Ѹ</button><button>ѹ</button></span><!--
      --><span><button>Ѡ</button><button>ѡ</button></span><!--
      --><span><button>Ѿ</button><button>ѿ</button></span><!--
-     --><span><button>Ѣ</button><button>ѣ</button></span>
+     --><span><button>Ꙑ</button><button>ꙑ</button></span><!--
+     --><span><button>Ѣ</button><button>ѣ</button></span><!--
+     --><span><button>Ꙓ</button><button>ꙓ</button></span>
       </div>
     </div>
 

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/unilang_virtualkeyboard_charsets.html
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/template/unilang_virtualkeyboard_charsets.html
@@ -1,0 +1,731 @@
+    <div data-layout="IPA" class="ulvkbd-buttonlist ulvkbd-layout-IPA" style="display: none">
+      <div>
+        <label>Vowels</label>
+
+        <button title="close central unrounded vowel">ɨ</button><!--
+     --><button title="close central rounded vowel">ʉ</button><!--
+     --><button title="close back unrounded vowel">ɯ</button><!--
+     --><button title="near-close near-front unrounded vowel">ɪ</button><!--
+     --><button title="near-close near-front rounded vowel">ʏ</button><!--
+     --><button title="near-close near-back rounded vowel">ʊ</button><!--
+     --><button title="close-mid front rounded vowel">ø</button><!--
+     --><button title="close-mid central unrounded vowel">ɘ</button><!--
+     --><button title="close-mid central rounded vowel">ɵ</button><!--
+     --><button title="close-mid back unrounded vowel">ɤ</button><!--
+     --><button title="mid-central vowel">ə</button><!--
+     --><button title="open-mid front unrounded vowel">ɛ</button><!--
+     --><button title="open-mid front rounded vowel">œ</button><!--
+     --><button title="open-mid central unrounded vowel">ɜ</button><!--
+     --><button title="open-mid central rounded vowel">ɞ</button><!--
+     --><button title="open-mid back unrounded vowel">ʌ</button><!--
+     --><button title="open-mid back rounded vowel">ɔ</button><!--
+     --><button title="near-open front unrounded vowel">æ</button><!--
+     --><button title="near-open central vowel">ɐ</button><!--
+     --><button title="open front rounded vowel">ɶ</button><!--
+     --><button title="open back unrounded vowel">ɑ</button><!--
+     --><button title="open back rounded vowel">ɒ</button>
+      </div>
+
+      <div>
+        <label>Pulmonic consonants</label>
+
+        <button title="voiceless retroflex plosive">ʈ</button><!--
+     --><button title="voiced retroflex plosive">ɖ</button><!--
+     --><button title="voiced palatal plosive">ɟ</button><!--
+     --><button title="voiced uvular plosive">ɢ</button><!--
+     --><button title="glottal stop">ʔ</button><!--
+     --><button title="labiodental nasal">ɱ</button><!--
+     --><button title="retroflex nasal">ɳ</button><!--
+     --><button title="palatal nasal">ɲ</button><!--
+     --><button title="velar nasal">ŋ</button><!--
+     --><button title="uvular nasal">ɴ</button><!--
+     --><button title="bilabial trill">ʙ</button><!--
+     --><button title="uvular trill">ʀ</button><!--
+     --><button title="labiodental flap">ⱱ</button><!--
+     --><button title="alveolar tap">ɾ</button><!--
+     --><button title="retroflex flap">ɽ</button><!--
+     --><button title="voiceless vilabial fricative">ɸ</button><!--
+     --><button title="voiced vilabial fricative">β</button><!--
+     --><button title="voiceless dental fricative">θ</button><!--
+     --><button title="voiced dental fricative">ð</button><!--
+     --><button title="voiceless postalveolar fricative">ʃ</button><!--
+     --><button title="voiced postalveolar fricative">ʒ</button><!--
+     --><button title="voiceless retroflex fricative">ʂ</button><!--
+     --><button title="voiced retroflex fricative">ʐ</button><!--
+     --><button title="voiceless palatal fricative">ç</button><!--
+     --><button title="voiced palatal fricative">ʝ</button><!--
+     --><button title="voiced velar fricative">ɣ</button><!--
+     --><button title="voiceless uvular fricative">χ</button><!--
+     --><button title="voiced uvular fricative">ʁ</button><!--
+     --><button title="voiceless pharyngeal fricative">ħ</button><!--
+     --><button title="voiced pharyngeal fricative">ʕ</button><!--
+     --><button title="voiced glottal fricative">ɦ</button><!--
+     --><button title="voiceless alveolar lateral fricative">ɬ</button><!--
+     --><button title="voiced alveolar lateral fricative">ɮ</button><!--
+     --><button title="labiodental approximant">ʋ</button><!--
+     --><button title="alveolar approximant">ɹ</button><!--
+     --><button title="retroflex approximant">ɻ</button><!--
+     --><button title="velar approximant">ɰ</button><!--
+     --><button title="retroflex lateral approximant">ɭ</button><!--
+     --><button title="palatal lateral approximant">ʎ</button><!--
+     --><button title="velar lateral approximant">ʟ</button><!--
+     --><button title="voiceless labio-velar approximant">ʍ</button><!--
+     --><button title="voiced labial-palatal approximant">ɥ</button><!--
+     --><button title="voiceless epiglottal fricative">ʜ</button><!--
+     --><button title="voiced epiglottal fricative">ʢ</button><!--
+     --><button title="epiglottal plosive">ʡ</button><!--
+     --><button title="voiceless alveo-palatal fricative">ɕ</button><!--
+     --><button title="voiceless alveo-palatal fricative">ʑ</button><!--
+     --><button title="alveolar lateral flap">ɺ</button><!--
+     --><button title="simultaneous [ʃ] and [x]">ɧ</button><!--
+     --><button title="velarized alveolar lateral approximant">ɫ</button><!--
+     --><button title="voiceless alveolar affricate">t͡s</button><!--
+     --><button title="voiced alveolar affricate">d͡z</button><!--
+     --><button title="voiceless postalveolar affricate">t͡ʃ</button><!--
+     --><button title="voiced postalveolar affricate">d͡ʒ</button><!--
+     --><button title="voiceless alveo-palatal affricate">t͡ɕ</button><!--
+     --><button title="voiced alveo-palatal affricate">d͡ʑ</button>
+      </div>
+
+      <div>
+        <label>Non-pulmonic consonants</label>
+
+        <button title="bilabial click">ʘ</button><!--
+     --><button title="dental click">ǀ</button><!--
+     --><button title="(post)alveolar click">ǃ</button><!--
+     --><button title="palatoalveolar click">ǂ</button><!--
+     --><button title="alveolar lateral click">ǁ</button><!--
+     --><button title="voiced bilabial implosive">ɓ</button><!--
+     --><button title="voiced dental/alveolar implosive">ɗ</button><!--
+     --><button title="voiced palatal implosive">ʄ</button><!--
+     --><button title="voiced velar implosive">ɠ</button><!--
+     --><button title="voiced uvular implosive">ʛ</button><!--
+     --><button title="ejective">ʼ</button>
+      </div>
+
+      <div>
+        <label>Suprasegmentals</label>
+
+        <button title="primary stress">ˈ</button><!--
+     --><button title="secondary stress">ˌ</button><!--
+     --><button title="long">ː</button><!--
+     --><button title="half-long">ˑ</button><!--
+     --><button data-char="̆" title="extra-short">&nbsp; ̆</button><!--
+     --><button data-char="͡" title="tie bar">&nbsp; ͡</button><!--
+     --><button data-char="͜" title="tie bar">&nbsp; ͜</button><!--
+     --><button title="linking">‿</button>
+      </div>
+
+      <div>
+        <label>Tones and word accents</label>
+
+        <button title="extra-high">˥</button><!--
+     --><button title="high">˦</button><!--
+     --><button title="mid">˧</button><!--
+     --><button title="low">˨</button><!--
+     --><button title="extra-low">˩</button><!--
+     --><button title="rising">˩˥</button><!--
+     --><button title="falling">˥˩</button><!--
+     --><button title="high rising">˦˥</button><!--
+     --><button title="low rising">˩˨</button><!--
+     --><button title="rising-falling">˧˦˧</button><!--
+     --><button title="downstep">↓</button><!--
+     --><button title="upstep">↑</button><!--
+     --><button title="global rise">↗</button><!--
+     --><button title="global fall">↘</button>
+      </div>
+
+      <div>
+        <label>Diacritics</label>
+
+        <button data-char="̥" title="voiceless">&nbsp; ̥</button><!--
+     --><button data-char="̊" title="voiceless">&nbsp; ̊</button><!--
+     --><button data-char="̬" title="voiced">&nbsp; ̬</button><!--
+     --><button data-char="̃" title="nasalized">&nbsp; ̃</button><!--
+     --><button data-char="̩" title="syllabic">&nbsp; ̩</button><!--
+     --><button data-char="̯" title="non-syllabic">&nbsp; ̯</button><!--
+     --><button data-char="̝" title="raised">&nbsp; ̝</button><!--
+     --><button data-char="̞" title="lowered">&nbsp; ̞</button><!--
+     --><button data-char="̟" title="advanced">&nbsp; ̟</button><!--
+     --><button data-char="̠" title="retracted">&nbsp; ̠</button><!--
+     --><button data-char="̪" title="dental">&nbsp; ̪</button><!--
+     --><button data-char="̺" title="apical">&nbsp; ̺</button><!--
+     --><button data-char="̹" title="more rounded">&nbsp; ̹</button><!--
+     --><button data-char="̜" title="less rounded">&nbsp; ̜</button><!--
+     --><button data-char="̽" title="mid-centralized">&nbsp; ̽</button><!--
+     --><button data-char="̤" title="breathy voiced">&nbsp; ̤</button><!--
+     --><button data-char="̰" title="creaky voiced">&nbsp; ̰</button><!--
+     --><button data-char="̼" title="linguolabial">&nbsp; ̼</button><!--
+     --><button data-char="̴" title="velarized or pharyngealized">&nbsp; ̴</button><!--
+     --><button data-char="̘" title="advanced tongue root">&nbsp; ̘</button><!--
+     --><button data-char="̙" title="retracted tongue root">&nbsp; ̙</button><!--
+     --><button data-char="̻" title="laminal">&nbsp; ̻</button><!--
+     --><button data-char="̚" title="not audibly released">&nbsp; ̚</button><!--
+     --><button title="syllabic or schwa">ᵊ</button><!--
+     --><button title="aspirated">ʰ</button><!--
+     --><button title="labialized">ʷ</button><!--
+     --><button title="palatalized">ʲ</button><!--
+     --><button title="velarized">ˠ</button><!--
+     --><button title="pharyngealized">ˤ</button><!--
+     --><button title="nasal release">ⁿ</button><!--
+     --><button title="lateral release">ˡ</button><!--
+     --><button title="breathy-voice aspirated">ʱ</button><!--
+     --><button title="rhotacized">˞</button>
+      </div>
+
+    </div>
+
+    <div data-layout="Latn" class="ulvkbd-buttonlist ulvkbd-layout-Latn" style="display: none">
+      <div>
+        <label>Acute</label>
+
+        <span><button>Á</button><button>á</button></span><!--
+     --><span><button>É</button><button>é</button></span><!--
+     --><span><button>Í</button><button>í</button></span><!--
+     --><span><button>Ó</button><button>ó</button></span><!--
+     --><span><button>Ú</button><button>ú</button></span><!--
+     --><span><button>Ý</button><button>ý</button></span><!--
+     --><span><button>Ć</button><button>ć</button></span><!--
+     --><span><button>Ĺ</button><button>ĺ</button></span><!--
+     --><span><button>Ń</button><button>ń</button></span><!--
+     --><span><button>Ŕ</button><button>ŕ</button></span><!--
+     --><span><button>Ś</button><button>ś</button></span><!--
+     --><span><button>Ź</button><button>ź</button></span><!--
+     --><span data-ext><button>Ǽ</button><button>ǽ</button></span><!--
+     --><span data-ext><button>Ǿ</button><button>ǿ</button></span>
+      </div>
+
+      <div>
+        <label>Grave</label>
+
+        <span><button>À</button><button>à</button></span><!--
+     --><span><button>È</button><button>è</button></span><!--
+     --><span><button>Ì</button><button>ì</button></span><!--
+     --><span><button>Ò</button><button>ò</button></span><!--
+     --><span><button>Ù</button><button>ù</button></span><!--
+     --><span data-ext><button>Ỳ</button><button>ỳ</button></span>
+      </div>
+
+      <div>
+        <label>Circumflex</label>
+
+        <span><button>Â</button><button>â</button></span><!--
+     --><span><button>Ê</button><button>ê</button></span><!--
+     --><span><button>Î</button><button>î</button></span><!--
+     --><span><button>Ô</button><button>ô</button></span><!--
+     --><span data-ext><button>Û</button><button>û</button></span><!--
+     --><span><button>Ŷ</button><button>ŷ</button></span><!--
+     --><span><button>Ĉ</button><button>ĉ</button></span><!--
+     --><span><button>Ĝ</button><button>ĝ</button></span><!--
+     --><span><button>Ĥ</button><button>ĥ</button></span><!--
+     --><span><button>Ĵ</button><button>ĵ</button></span><!--
+     --><span><button>Ŝ</button><button>ŝ</button></span><!--
+     --><span data-ext><button>Ŵ</button><button>ŵ</button></span>
+      </div>
+
+      <label>Umlauts and diaereses</label>
+
+      <div>
+        <span><button>Ä</button><button>ä</button></span><!--
+     --><span><button>Ë</button><button>ë</button></span><!--
+     --><span><button>Ï</button><button>ï</button></span><!--
+     --><span><button>Ö</button><button>ö</button></span><!--
+     --><span><button>Ü</button><button>ü</button></span><!--
+     --><span><button>Ÿ</button><button>ÿ</button></span>
+      </div>
+
+      <div>
+        <label>Tilde</label>
+
+        <span><button>Ã</button><button>ã</button></span><!--
+     --><span data-ext><button>Ẽ</button><button>ẽ</button></span><!--
+     --><span data-ext><button>Ĩ</button><button>ĩ</button></span><!--
+     --><span><button>Õ</button><button>õ</button></span><!--
+     --><span data-ext><button>Ũ</button><button>ũ</button></span><!--
+     --><span data-ext><button>Ỹ</button><button>ỹ</button></span><!--
+     --><span><button>Ñ</button><button>ñ</button></span>
+      </div>
+
+
+      <div>
+        <label>Ring</label>
+
+        <span><button>Å</button><button>å</button></span><!--
+     --><span><button>Ů</button><button>ů</button></span>
+      </div>
+
+
+      <div>
+        <label>Ogonek</label>
+
+        <span><button>Ą</button><button>ą</button></span><!--
+     --><span><button>Ę</button><button>ę</button></span><!--
+     --><span data-ext><button>Į</button><button>į</button></span><!--
+     --><span data-ext><button>Ǫ</button><button>ǫ</button></span><!--
+     --><span><button>Ų</button><button>ų</button></span>
+      </div>
+
+
+      <div>
+        <label>Cedilla</label>
+
+        <span><button>Ç</button><button>ç</button></span><!--
+     --><span><button>Ģ</button><button>ģ</button></span><!--
+     --><span><button>Ķ</button><button>ķ</button></span><!--
+     --><span><button>Ļ</button><button>ļ</button></span><!--
+     --><span><button>Ņ</button><button>ņ</button></span><!--
+     --><span><button>Ş</button><button>ş</button></span>
+      </div>
+
+
+      <div>
+        <label>Macron</label>
+
+        <span><button>Ā</button><button>ā</button></span><!--
+     --><span><button>Ē</button><button>ē</button></span><!--
+     --><span><button>Ī</button><button>ī</button></span><!--
+     --><span><button>Ō</button><button>ō</button></span><!--
+     --><span><button>Ū</button><button>ū</button></span><!--
+     --><span data-ext><button>Ȳ</button><button>ȳ</button></span><!--
+     --><span><button>Ǣ</button><button>ǣ</button></span>
+      </div>
+
+
+      <div>
+        <label>Double acute</label>
+
+        <span><button>Ő</button><button>ő</button></span><!--
+     --><span><button>Ű</button><button>ű</button></span>
+      </div>
+
+      <div data-ext>
+        <label>Double grave</label>
+
+        <span><button>Ȁ</button><button>ȁ</button></span><!--
+     --><span><button>Ȅ</button><button>ȅ</button></span><!--
+     --><span><button>Ȉ</button><button>ȉ</button></span><!--
+     --><span><button>Ȍ</button><button>ȍ</button></span><!--
+     --><span><button>Ȕ</button><button>ȕ</button></span><!--
+     --><span><button>Ȑ</button><button>ȑ</button></span><!--
+     -->
+      </div>
+
+
+      <div>
+        <label>Breve</label>
+
+        <span><button>Ă</button><button>ă</button></span><!--
+     --><span data-ext><button>Ĕ</button><button>ĕ</button></span><!--
+     --><span data-ext><button>Ĭ</button><button>ĭ</button></span><!--
+     --><span data-ext><button>Ŏ</button><button>ŏ</button></span><!--
+     --><span><button>Ŭ</button><button>ŭ</button></span><!--
+     --><span><button>Ğ</button><button>ğ</button></span>
+      </div>
+
+
+      <div data-ext>
+        <label>Inverted breve</label>
+
+        <span><button>Ȃ</button><button>ȃ</button></span><!--
+     --><span><button>Ȇ</button><button>ȇ</button></span><!--
+     --><span><button>Ȋ</button><button>ȋ</button></span><!--
+     --><span><button>Ȏ</button><button>ȏ</button></span><!--
+     --><span><button>Ȗ</button><button>ȗ</button></span><!--
+     --><span><button>Ȓ</button><button>ȓ</button></span>
+      </div>
+
+
+      <div>
+        <label>Dot above</label>
+
+        <span data-ext><button>Ȧ</button><button>ȧ</button></span><!--
+     --><span><button>Ė</button><button>ė</button></span><!--
+     --><span><button>İ</button><button>ı</button></span><!--
+     --><span data-ext><button>Ȯ</button><button>ȯ</button></span><!--
+     --><span data-ext><button>Ẏ</button><button>ẏ</button></span><!--
+     --><span data-ext><button>Ċ</button><button>ċ</button></span><!--
+     --><span data-ext><button>Ġ</button><button>ġ</button></span><!--
+     --><span><button>Ż</button><button>ż</button></span>
+      </div>
+
+
+      <div>
+        <label>Caron and haček</label>
+
+        <span data-ext><button>Ǎ</button><button>ǎ</button></span><!--
+     --><span><button>Ě</button><button>ě</button></span><!--
+     --><span data-ext><button>Ǐ</button><button>ǐ</button></span><!--
+     --><span data-ext><button>Ǒ</button><button>ǒ</button></span><!--
+     --><span data-ext><button>Ǔ</button><button>ǔ</button></span><!--
+     --><span><button>Č</button><button>č</button></span><!--
+     --><span><button>Ď</button><button>ď</button></span><!--
+     --><span><button>Ľ</button><button>ľ</button></span><!--
+     --><span><button>Ň</button><button>ň</button></span><!--
+     --><span><button>Ř</button><button>ř</button></span><!--
+     --><span><button>Š</button><button>š</button></span><!--
+     --><span><button>Ť</button><button>ť</button></span><!--
+     --><span><button>Ž</button><button>ž</button></span>
+      </div>
+
+
+      <div>
+        <label>Comma below</label>
+
+        <span><button>Ș</button><button>ș</button></span><!--
+     --><span><button>Ț</button><button>ț</button></span>
+      </div>
+
+
+      <div>
+        <label>Ligatures</label>
+
+        <span><button>Æ</button><button>æ</button></span><!--
+     --><span><button>Œ</button><button>œ</button></span><!--
+     --><span><button>ß</button></span>
+      </div>
+
+
+      <div>
+        <label>Stroke</label>
+
+        <span><button>Ø</button><button>ø</button></span><!--
+     --><span><button>Đ</button><button>đ</button></span><!--
+     --><span data-ext><button>Ħ</button><button>ħ</button></span><!--
+     --><span><button>Ł</button><button>ł</button></span><!--
+     --><span data-ext><button>Ŧ</button><button>ŧ</button></span>
+      </div>
+
+
+      <div>
+        <label>Others</label>
+
+        <span data-ext><button>Ə</button><button>ə</button></span><!--
+     --><span data-ext><button>Ŋ</button><button>ŋ</button></span><!--
+     --><span><button>Þ</button><button>þ</button></span><!--
+     --><span><button>Ð</button><button>ð</button></span>
+      </div>
+
+      <div style="clear:both"></div>
+    </div>
+
+    <div data-layout="Cyrl" class="ulvkbd-buttonlist ulvkbd-layout-Cyrl" style="display: none">
+      <div>
+        <label>Plain</label>
+
+        <span><button>А</button><button>а</button></span><!--
+     --><span><button>Б</button><button>б</button></span><!--
+     --><span><button>В</button><button>в</button></span><!--
+     --><span><button>Г</button><button>г</button></span><!--
+     --><span><button>Ґ</button><button>ґ</button></span><!--
+     --><span><button>Д</button><button>д</button></span><!--
+     --><span><button>Ђ</button><button>ђ</button></span><!--
+     --><span data-ext><button>Ѓ</button><button>ѓ</button></span><!--
+     --><span><button>Е</button><button>е</button></span><!--
+     --><span><button>Ё</button><button>ё</button></span><!--
+     --><span><button>Є</button><button>є</button></span><!--
+     --><span><button>Ж</button><button>ж</button></span><!--
+     --><span><button>З</button><button>з</button></span><!--
+     --><span data-ext><button>З́</button><button>з́</button></span><!--
+     --><span data-ext><button>Ѕ</button><button>ѕ</button></span><!--
+     --><span><button>И</button><button>и</button></span><!--
+     --><span><button>І</button><button>і</button></span><!--
+     --><span><button>Ї</button><button>ї</button></span><!--
+     --><span><button>Й</button><button>й</button></span><!--
+     --><span><button>Ј</button><button>ј</button></span><!--
+     --><span><button>К</button><button>к</button></span><!--
+     --><span><button>Л</button><button>л</button></span><!--
+     --><span><button>Љ</button><button>љ</button></span><!--
+     --><span><button>Љ</button><button>љ</button></span><!--
+     --><span><button>М</button><button>м</button></span><!--
+     --><span><button>Н</button><button>н</button></span><!--
+     --><span><button>Њ</button><button>њ</button></span><!--
+     --><span><button>О</button><button>о</button></span><!--
+     --><span><button>П</button><button>п</button></span><!--
+     --><span><button>Р</button><button>р</button></span><!--
+     --><span><button>С</button><button>с</button></span><!--
+     --><span data-ext><button>С́</button><button>с́</button></span><!--
+     --><span><button>Т</button><button>т</button></span><!--
+     --><span><button>Ћ</button><button>ћ</button></span><!--
+     --><span><button>Ќ</button><button>ќ</button></span><!--
+     --><span><button>У</button><button>у</button></span><!--
+     --><span data-ext><button>Ў</button><button>ў</button></span><!--
+     --><span><button>Ф</button><button>ф</button></span><!--
+     --><span><button>Х</button><button>х</button></span><!--
+     --><span><button>Ц</button><button>ц</button></span><!--
+     --><span><button>Ч</button><button>ч</button></span><!--
+     --><span><button>Џ</button><button>џ</button></span><!--
+     --><span><button>Ш</button><button>ш</button></span><!--
+     --><span><button>Щ</button><button>щ</button></span><!--
+     --><span><button>Щ</button><button>щ</button></span><!--
+     --><span><button>Ъ</button><button>ъ</button></span><!--
+     --><span><button>Ы</button><button>ы</button></span><!--
+     --><span><button>Ь</button><button>ь</button></span><!--
+     --><span><button>Э</button><button>э</button></span><!--
+     --><span><button>Ю</button><button>ю</button></span><!--
+     --><span><button>Я</button><button>я</button></span>
+      </div>
+
+      <div data-ext>
+        <label>Acute</label>
+
+        <span><button>А&#769;</button><button>а&#769;</button></span><!--
+     --><span><button>Е&#769;</button><button>е&#769;</button></span><!--
+     --><span><button>И&#769;</button><button>и&#769;</button></span><!--
+     --><span><button>О&#769;</button><button>о&#769;</button></span><!--
+     --><span><button>У&#769;</button><button>у&#769;</button></span><!--
+     --><span><button>Ы&#769;</button><button>ы&#769;</button></span><!--
+     --><span><button>Э&#769;</button><button>э&#769;</button></span><!--
+     --><span><button>Ю&#769;</button><button>ю&#769;</button></span><!--
+     --><span><button>Я&#769;</button><button>я&#769;</button></span>
+      </div>
+
+
+      <div data-ext>
+        <label>Non-slavic</label>
+
+        <span><button>Ӏ</button><button>ӏ</button></span><!--
+     --><span><button>Ә</button><button>ә</button></span><!--
+     --><span><button>Ғ</button><button>ғ</button></span><!--
+     --><span><button>Ҙ</button><button>ҙ</button></span><!--
+     --><span><button>Ҫ</button><button>ҫ</button></span><!--
+     --><span><button>Ҡ</button><button>ҡ</button></span><!--
+     --><span><button>Қ</button><button>қ</button></span><!--
+     --><span><button>Ң</button><button>ң</button></span><!--
+     --><span><button>Ө</button><button>ө</button></span><!--
+     --><span><button>Ү</button><button>ү</button></span><!--
+     --><span><button>Ұ</button><button>ұ</button></span><!--
+     --><span><button>Һ</button><button>һ</button></span>
+      </div>
+
+      <div data-ext>
+        <label>Archaic</label>
+
+        <span><button>Ꙗ</button><button>ꙗ</button></span><!--
+     --><span><button>Ѥ</button><button>ѥ</button></span><!--
+     --><span><button>Ѧ</button><button>ѧ</button></span><!--
+     --><span><button>Ѫ</button><button>ѫ</button></span><!--
+     --><span><button>Ѩ</button><button>ѩ</button></span><!--
+     --><span><button>Ѭ</button><button>ѭ</button></span><!--
+     --><span><button>Ѯ</button><button>ѯ</button></span><!--
+     --><span><button>Ѱ</button><button>ѱ</button></span><!--
+     --><span><button>Ѳ</button><button>ѳ</button></span><!--
+     --><span><button>Ѵ</button><button>ѵ</button></span><!--
+     --><span><button>Ѷ</button><button>ѷ</button></span><!--
+     --><span><button>Ҁ</button><button>ҁ</button></span><!--
+     --><span><button>Ѹ</button><button>ѹ</button></span><!--
+     --><span><button>Ѡ</button><button>ѡ</button></span><!--
+     --><span><button>Ѿ</button><button>ѿ</button></span><!--
+     --><span><button>Ѣ</button><button>ѣ</button></span>
+      </div>
+    </div>
+
+    <div data-layout="Grek" class="ulvkbd-buttonlist ulvkbd-layout-Grek" style="display: none">
+      <div>
+        <label>Plain</label>
+
+        <span><button>Α</button><button>α</button></span><!--
+     --><span><button>Β</button><button>β</button></span><!--
+     --><span><button>Γ</button><button>γ</button></span><!--
+     --><span><button>Δ</button><button>δ</button></span><!--
+     --><span><button>Ε</button><button>ε</button></span><!--
+     --><span><button>Ζ</button><button>ζ</button></span><!--
+     --><span><button>Η</button><button>η</button></span><!--
+     --><span><button>Θ</button><button>θ</button></span><!--
+     --><span><button>Ι</button><button>ι</button></span><!--
+     --><span><button>Κ</button><button>κ</button></span><!--
+     --><span><button>Λ</button><button>λ</button></span><!--
+     --><span><button>Μ</button><button>μ</button></span><!--
+     --><span><button>Ν</button><button>ν</button></span><!--
+     --><span><button>Ξ</button><button>ξ</button></span><!--
+     --><span><button>Ο</button><button>ο</button></span><!--
+     --><span><button>Π</button><button>π</button></span><!--
+     --><span><button>Ρ</button><button>ρ</button></span><!--
+     --><span><button>Σ</button><button>σ</button><button>ς</button></span><!--
+     --><span><button>Τ</button><button>τ</button></span><!--
+     --><span><button>Υ</button><button>υ</button></span><!--
+     --><span><button>Φ</button><button>φ</button></span><!--
+     --><span><button>Χ</button><button>χ</button></span><!--
+     --><span><button>Ψ</button><button>ψ</button></span><!--
+     --><span><button>Ω</button><button>ω</button></span>
+
+        <div data-ext>
+          <span><button>ᾼ</button><button>ᾳ</button></span><!--
+       --><span><button>ῌ</button><button>ῃ</button></span><!--
+       --><span><button>ῼ</button><button>ῳ</button></span>
+        </div>
+
+        <div>
+          <em>Acute:</em>
+
+          <span><button>Ά</button><button>ά</button></span><!--
+       --><span><button>Έ</button><button>έ</button></span><!--
+       --><span><button>Ή</button><button>ή</button></span><!--
+       --><span><button>Ί</button><button>ί</button></span><!--
+       --><span><button>Ό</button><button>ό</button></span><!--
+       --><span><button>Ύ</button><button>ύ</button></span><!--
+       --><span><button>Ώ</button><button>ώ</button></span>
+          <span data-ext><button>ᾴ</button><button>ῄ</button><button>ῴ</button></span>
+        </div>
+
+        <div data-ext>
+          <em>Grave:</em>
+
+          <span><button>Ὰ</button><button>ὰ</button></span><!--
+       --><span><button>Ὲ</button><button>ὲ</button></span><!--
+       --><span><button>Ὴ</button><button>ὴ</button></span><!--
+       --><span><button>Ὶ</button><button>ὶ</button></span><!--
+       --><span><button>Ὸ</button><button>ὸ</button></span><!--
+       --><span><button>Ὺ</button><button>ὺ</button></span><!--
+       --><span><button>Ὼ</button><button>ὼ</button></span>
+          <span><button>ᾲ</button><button>ῂ</button><button>ῲ</button></span>
+        </div>
+
+        <div data-ext>
+          <em>Circumflex:</em>
+
+          <button>ᾶ</button><!--
+       --><button>ῆ</button><!--
+       --><button>ῖ</button><!--
+       --><button>ῦ</button><!--
+       --><button>ῶ</button>
+
+          <button>ᾷ</button><button>ῇ</button><button>ῷ</button>
+        </div>
+      </div>
+
+      <div data-ext>
+        <label>Smooth breathing</label>
+
+        <span><button>Ἀ</button><button>ἀ</button></span><!--
+     --><span><button>Ἐ</button><button>ἐ</button></span><!--
+     --><span><button>Ἠ</button><button>ἠ</button></span><!--
+     --><span><button>Ἰ</button><button>ἰ</button></span><!--
+     --><span><button>Ὀ</button><button>ὀ</button></span><!--
+     --><span><button>ὐ</button></span><!--
+     --><span><button>Ὠ</button><button>ὠ</button></span>
+
+        <span><button>ᾈ</button><button>ᾀ</button></span><!--
+     --><span><button>ᾘ</button><button>ᾐ</button></span><!--
+     --><span><button>ᾨ</button><button>ᾠ</button></span>
+
+        <div>
+          <em>Acute:</em>
+
+          <span><button>Ἄ</button><button>ἄ</button></span><!--
+       --><span><button>Ἔ</button><button>ἔ</button></span><!--
+       --><span><button>Ἤ</button><button>ἤ</button></span><!--
+       --><span><button>Ἴ</button><button>ἴ</button></span><!--
+       --><span><button>Ὄ</button><button>ὄ</button></span><!--
+       --><span><button>ὔ</button></span><!--
+       --><span><button>Ὤ</button><button>ὤ</button></span>
+           
+          <span><button>ᾌ</button><button>ᾄ</button></span><!--
+       --><span><button>ᾜ</button><button>ᾔ</button></span><!--
+       --><span><button>ᾬ</button><button>ᾤ</button></span>
+        </div>
+
+        <div>
+          <em>Grave:</em>
+
+          <span><button>Ἂ</button><button>ἂ</button></span><!--
+       --><span><button>Ἒ</button><button>ἒ</button></span><!--
+       --><span><button>Ἢ</button><button>ἢ</button></span><!--
+       --><span><button>Ἲ</button><button>ἲ</button></span><!--
+       --><span><button>Ὂ</button><button>ὂ</button></span><!--
+       --><span><button>ὒ</button></span><!-- 
+       --><span><button>Ὢ</button><button>ὢ</button></span>
+          
+          <span><button>ᾊ</button><button>ᾂ</button></span><!--
+       --><span><button>ᾚ</button><button>ᾒ</button></span><!--
+       --><span><button>ᾪ</button><button>ᾢ</button></span>
+        </div>
+
+        <div>
+          <em>Circumflex:</em>
+
+          <span><button>Ἆ</button><button>ἆ</button></span><!--
+       --><span><button>Ἦ</button><button>ἦ</button></span><!--
+       --><span><button>Ἶ</button><button>ἶ</button></span><!--
+       --><span><button>ὖ</button></span><!--
+       --><span><button>Ὦ</button><button>ὦ</button></span>
+          
+          <span><button>ᾎ</button><button>ᾆ</button></span><!--
+       --><span><button>ᾞ</button><button>ᾖ</button></span><!--
+       --><span><button>ᾮ</button><button>ᾦ</button></span>
+        </div>
+      </div>
+
+      <div data-ext>
+        <label>Rough breathing</label>
+
+        <span><button>Ἁ</button><button>ἁ</button></span><!--
+     --><span><button>Ἑ</button><button>ἑ</button></span><!--
+     --><span><button>Ἡ</button><button>ἡ</button></span><!--
+     --><span><button>Ἱ</button><button>ἱ</button></span><!--
+     --><span><button>Ὁ</button><button>ὁ</button></span><!--
+     --><span><button>Ὑ</button><button>ὑ</button></span><!--
+     --><span><button>Ὡ</button><button>ὡ</button></span>
+
+        <span><button>ᾉ</button><button>ᾁ</button></span><!--
+     --><span><button>ᾙ</button><button>ᾑ</button></span><!--
+     --><span><button>ᾩ</button><button>ᾡ</button></span>
+
+        <span><button>Ῥ</button><button>ῥ</button></span>
+
+        <div>
+          <em>Acute:</em>
+
+          <span><button>Ἅ</button><button>ἅ</button></span><!--
+       --><span><button>Ἕ</button><button>ἕ</button></span><!--
+       --><span><button>Ἥ</button><button>ἥ</button></span><!--
+       --><span><button>Ἵ</button><button>ἵ</button></span><!--
+       --><span><button>Ὅ</button><button>ὅ</button></span><!--
+       --><span><button>Ὕ</button><button>ὕ</button></span><!--
+       --><span><button>Ὥ</button><button>ὥ</button></span>
+
+          <span><button>ᾍ</button><button>ᾅ</button></span><!--
+       --><span><button>ᾝ</button><button>ᾕ</button></span><!--
+       --><span><button>ᾭ</button><button>ᾥ</button></span>
+        </div>
+
+        <div>
+          <em>Grave:</em>
+
+          <span><button>Ἃ</button><button>ἃ</button></span><!--
+       --><span><button>Ἓ</button><button>ἓ</button></span><!--
+       --><span><button>Ἣ</button><button>ἣ</button></span><!--
+       --><span><button>Ἳ</button><button>ἳ</button></span><!--
+       --><span><button>Ὃ</button><button>ὃ</button></span><!--
+       --><span><button>Ὓ</button><button>ὓ</button></span><!--
+       --><span><button>Ὣ</button><button>ὣ</button></span>
+
+          <span><button>ᾋ</button><button>ᾃ</button></span><!--
+       --><span><button>ᾛ</button><button>ᾓ</button></span><!--
+       --><span><button>ᾫ</button><button>ᾣ</button></span>
+        </div>
+
+        <div>
+          <em>Circumflex:</em>
+
+          <span><button>Ἇ</button><button>ἇ</button></span><!--
+       --><span><button>Ἧ</button><button>ἧ</button></span><!--
+       --><span><button>Ἷ</button><button>ἷ</button></span><!--
+       --><span><button>Ὗ</button><button>ὗ</button></span><!--
+       --><span><button>Ὧ</button><button>ὧ</button></span>
+
+          <span><button>ᾏ</button><button>ᾇ</button></span><!--
+       --><span><button>ᾟ</button><button>ᾗ</button></span><!--
+       --><span><button>ᾯ</button><button>ᾧ</button></span>
+        </div>
+      </div>
+
+      <div>
+        <label>Diaeresis</label>
+
+        <span><button>Ϊ</button><button>ϊ</button></span><!--
+     --><span><button>ΐ</button><button data-ext>ῒ</button><button data-ext>ῗ</button></span><!--
+     --><span><button>Ϋ</button><button>ϋ</button></span><!--
+     --><span><button>ΰ</button><button data-ext>ῢ</button><button data-ext>ῧ</button></span>
+      </div>
+
+    </div>

--- a/phpBB3/ext/unilang/virtualkeyboard/styles/all/theme/virtualkeyboard.css
+++ b/phpBB3/ext/unilang/virtualkeyboard/styles/all/theme/virtualkeyboard.css
@@ -1,5 +1,0 @@
-
-#ulkvbd .ulvkbd-buttonlist > button {
-  margin-left: 0; margin-right: 0;
-}
-


### PR DESCRIPTION
This adds Latin/Roman, Cyrillic, and Greek character sets - basic, as well as extended - to the virtual keyboard extension.

Also, enhances the functionality: the character sets are only loaded (via AJAX) when needed, to minimize overload; settings on virtual keyboard visibility and the set to use are now stored in cookies.

It’s generally better. :)
